### PR TITLE
Fixing logic for jumping onto ropes and ladders

### DIFF
--- a/Character/Player.cpp
+++ b/Character/Player.cpp
@@ -26,6 +26,8 @@
 #include "../Net/Packets/GameplayPackets.h"
 #include "../Net/Packets/InventoryPackets.h"
 
+#include <ctime>
+
 namespace ms
 {
 	const PlayerNullState nullstate;
@@ -66,6 +68,7 @@ namespace ms
 	{
 		attacking = false;
 		underwater = false;
+		last_jump = (std::time_t)(-1);
 
 		set_state(Char::State::STAND);
 		set_direction(true);
@@ -516,5 +519,16 @@ namespace ms
 	Optional<const Ladder> Player::get_ladder() const
 	{
 		return ladder;
+	}
+
+	void Player::mark_jump_for_cooldown()
+	{
+		last_jump = std::time(nullptr);
+	}
+
+	bool Player::is_jump_cooldown()
+	{
+		std::time_t current_time = std::time(nullptr);
+		return (current_time - last_jump) < 1;
 	}
 }

--- a/Character/Player.h
+++ b/Character/Player.h
@@ -32,6 +32,8 @@
 #include "../Gameplay/MapleMap/Layer.h"
 #include "../Gameplay/MapleMap/MapInfo.h"
 
+#include <ctime>
+
 namespace ms
 {
 	class Player : public Playable, public Char
@@ -141,6 +143,12 @@ namespace ms
 		TeleportRock& get_teleportrock();
 		// Obtain a reference to the player's MonsterBook
 		MonsterBook& get_monsterbook();
+		
+		// Update timestamp of a jump for disabling climbing
+		void mark_jump_for_cooldown();
+
+		// Check if a jump was recently performed to disable climbing
+		bool is_jump_cooldown();
 
 	private:
 		CharStats stats;
@@ -165,5 +173,7 @@ namespace ms
 		Optional<const Ladder> ladder;
 
 		bool underwater;
+
+		std::time_t last_jump;
 	};
 }

--- a/Character/PlayerStates.cpp
+++ b/Character/PlayerStates.cpp
@@ -17,6 +17,7 @@
 //////////////////////////////////////////////////////////////////////////////////
 #include "PlayerStates.h"
 
+
 namespace ms
 {
 	// Base class
@@ -134,12 +135,19 @@ namespace ms
 				player.set_direction(true);
 				break;
 			case KeyAction::Id::JUMP:
-				play_jumpsound();
-				player.get_phobj().vforce = -player.get_jumpforce();
-				break;
-			case KeyAction::Id::DOWN:
-				player.set_state(Char::State::PRONE);
-				break;
+				if (player.get_phobj().enablejd && player.is_key_down(KeyAction::Id::DOWN))
+				{
+					play_jumpsound();
+					player.get_phobj().y = player.get_phobj().groundbelow;
+					player.get_phobj().hspeed = 0.0;
+					player.set_state(Char::State::FALL);
+				}
+				else 
+                {
+					play_jumpsound();
+					player.get_phobj().vforce = -player.get_jumpforce();
+					break;
+				}
 			}
 		}
 	}
@@ -385,6 +393,7 @@ namespace ms
 			case KeyAction::Id::JUMP:
 				if (player.is_key_down(KeyAction::Id::LEFT))
 				{
+					player.mark_jump_for_cooldown();
 					play_jumpsound();
 					player.set_direction(false);
 					player.get_phobj().hspeed = -player.get_walkforce() * 8.0;
@@ -393,6 +402,7 @@ namespace ms
 				}
 				else if (player.is_key_down(KeyAction::Id::RIGHT))
 				{
+					player.mark_jump_for_cooldown();
 					play_jumpsound();
 					player.set_direction(true);
 					player.get_phobj().hspeed = player.get_walkforce() * 8.0;

--- a/Gameplay/Stage.cpp
+++ b/Gameplay/Stage.cpp
@@ -155,6 +155,22 @@ namespace ms
 		portals.update(player.get_position());
 		camera.update(player.get_position());
 
+        // Check if player is currently aligned with a ladder and is attempting to hold on
+		if (!player.is_climbing() && player.is_key_down(KeyAction::Id::UP) && !player.is_jump_cooldown()) {
+			Optional<const Ladder> ladder = mapinfo.findladder(player.get_position(), true);
+			if (ladder) {
+				player.set_ladder(ladder);
+			}
+		}
+
+        // Check if player is currently aligned with a ladder and is attempting to hold on - this time for down
+		if (!player.is_climbing() && player.is_key_down(KeyAction::Id::DOWN) && !player.is_jump_cooldown()) {
+			Optional<const Ladder> ladder = mapinfo.findladder(player.get_position(), false);
+			if (ladder) {
+				player.set_ladder(ladder);
+			}
+		}
+		
 		if (player.is_invincible())
 			return;
 


### PR DESCRIPTION
Fixing logic for jumping onto ropes and ladders (by checked with every map update), as well as some other unwanted side effects (DOWN shouldn't stop character while moving), to be more in line with the GMS client
This resolves this issue: 
https://github.com/ryantpayton/HeavenClient/issues/11
For me, the fix feels great, and figured no reason not to PR - but I'm not sure what's the performance impact of these checks - for your consideration 