### PR TITLE
Fixed auto login

### DIFF
--- a/IO/UIStateLogin.cpp
+++ b/IO/UIStateLogin.cpp
@@ -31,11 +31,13 @@ namespace ms
 	{
 		focused = UIElement::Type::NONE;
 
+#ifndef DEBUG
 		bool start_shown = Configuration::get().get_start_shown();
 
 		if (!start_shown)
 			emplace<UILogo>();
 		else
+#endif // !DEBUG
 			emplace<UILogin>();
 	}
 

--- a/IO/UITypes/UILogin.cpp
+++ b/IO/UITypes/UILogin.cpp
@@ -146,19 +146,6 @@ namespace ms
 		{
 			account.set_state(Textfield::State::FOCUSED);
 		}
-
-		if (Configuration::get().get_auto_login())
-		{
-			UI::get().emplace<UILoginWait>([]() {});
-
-			auto loginwait = UI::get().get_element<UILoginWait>();
-
-			if (loginwait && loginwait->is_active())
-				LoginPacket(
-					Configuration::get().get_auto_acc(),
-					Configuration::get().get_auto_pass()
-				).dispatch();
-		}
 	}
 
 	void UILogin::draw(float alpha) const
@@ -182,6 +169,19 @@ namespace ms
 
 	void UILogin::update()
 	{
+		if (Configuration::get().get_auto_login())
+		{
+			auto loginwait = UI::get().get_element<UILoginWait>();
+
+			if (!loginwait || !loginwait->is_active()) {
+				UI::get().emplace<UILoginWait>([]() {});
+
+				LoginPacket(
+					Configuration::get().get_auto_acc(),
+					Configuration::get().get_auto_pass()
+				).dispatch();
+			}
+		}
 		UIElement::update();
 
 		account.update(position);


### PR DESCRIPTION
The auto login was actually not working, and I wanted to have it in order to launch and debug the game faster. 

The reason why auto login is not working is because the loginwait UI being added at the constructor of the UILogin. At the time of constructing the UILogin, the UIStateLogin has not yet been created, so the loginwait will just be added to the UIStateNull instead, which does nothing. Technically, the login packet dispatch can be issued at the constructor, and the loginwait UI can be added in the update loop, but I think it is more clear if they are together because they are indicating the one functionality together.

One side effect is that if you log off the game, it will still log you back in automatically. I figure it is fine since auto login should only be a debug feature and not enabled in actual release builds.

I also just disables the logo display when in DEBUG since this commit is to speed up launching the game.

First time contributing, let me know any stylistic or correctness issues. 